### PR TITLE
Фикс оформления законов

### DIFF
--- a/modular_joparamble/translate/code/tron.dm
+++ b/modular_joparamble/translate/code/tron.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_EMPTY(lord_decrees)
 GLOBAL_LIST_INIT(laws_of_the_land, initialize_laws_of_the_land())
 
 /proc/initialize_laws_of_the_land()
-	var/list/laws = strings()
+	var/list/laws = strings("lawsets")
 	var/list/lawsets_weighted = list()
 	for(var/lawset_name as anything in laws)
 		var/list/lawset = laws[lawset_name]


### PR DESCRIPTION
Из-за некоректного оформления кода, игра изображала законы вот так
![image](https://github.com/user-attachments/assets/1d136891-7224-4a70-9c9c-2015d7bcf9e9)
