### PR TITLE
fix inheritance in code/modules/clothing/rogueclothes/armor.dm

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -886,7 +886,7 @@
 	smeltresult = /obj/item/ingot/steel
 	armor_class = ARMOR_CLASS_HEAVY
 
-/obj/item/clothing/suit/roguetown/armor/leathervest
+/obj/item/clothing/suit/roguetown/armor/leather/vest/v2
 	name = "leather vest"
 	desc = "A simple vest made of leather, provides poor protection."
 	icon_state = "leathervest"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -893,7 +893,7 @@
 	item_state = "leathervest"
 	allowed_race = CLOTHED_RACES_TYPES
 
-/obj/item/clothing/suit/roguetown/armor/valorianarmor
+/obj/item/clothing/suit/roguetown/armor/gambeson/valorianarmor
 	name = "valorian armor"
 	desc = "Valorian armor made using heavy cloth."
 	icon_state = "valorian_armor"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -283,16 +283,12 @@
 	smeltresult = /obj/item/ingot/iron
 	armor_class = ARMOR_CLASS_MEDIUM
 
-/obj/item/clothing/suit/roguetown/armor/shortbrigandine
+/obj/item/clothing/suit/roguetown/armor/plate/half/iron/shortbrigandine
 	name = "fancy brigandine"
 	desc = "A coat with plates concealed inside an exterior fabric. This one is a bit nicer looking than most others and the fabric on the exterior of the armor better conceals the plate beneath."
-	body_parts_covered = CHEST|VITALS
 	icon_state = "oa_short"
 	item_state = "oa_short"
 	boobed = TRUE
-	max_integrity = 200
-	smeltresult = /obj/item/ingot/iron
-	armor_class = ARMOR_CLASS_MEDIUM
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/ironharness
 	name = "iron harness"

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -954,7 +954,7 @@
 	smeltresult = /obj/item/ash
 	equip_delay_self = 15
 
-/obj/item/clothing/suit/roguetown/armor/hide/bearfur
+/obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur
 	name = "bear fur"
 	desc = "Thick and warm."
 	body_parts_covered = CHEST|VITALS

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -945,7 +945,7 @@
 	smeltresult = /obj/item/ingot/gold
 	armor_class = ARMOR_CLASS_MEDIUM	
 
-/obj/item/clothing/suit/roguetown/armor/bone/chestplate
+/obj/item/clothing/suit/roguetown/armor/carapace/bone
 	name = "bone chestplate"
 	desc = "A chestplate made using bone."
 	body_parts_covered = CHEST

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -944,16 +944,13 @@
 /obj/item/clothing/suit/roguetown/armor/carapace/bone
 	name = "bone chestplate"
 	desc = "A chestplate made using bone."
-	body_parts_covered = CHEST
 	icon_state = "bonearmor"
 	item_state = "bonrearmor"
 	smeltresult = /obj/item/ash
-	equip_delay_self = 15
 
 /obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur
 	name = "bear fur"
 	desc = "Thick and warm."
-	body_parts_covered = CHEST|VITALS
 	icon_state = "bearfur"
 	item_state = "bearfur"
 	smeltresult = /obj/item/ash

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -946,6 +946,7 @@
 	desc = "A chestplate made using bone."
 	icon_state = "bonearmor"
 	item_state = "bonrearmor"
+	armor = list("blunt" = 50, "slash" = 25, "stab" = 20, "bullet" = 15, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 0)
 	smeltresult = /obj/item/ash
 
 /obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -84,7 +84,7 @@
 			neck = /obj/item/clothing/neck/roguetown/psicross/malum
 			pants = /obj/item/clothing/under/roguetown/trou/leather
 			shoes = /obj/item/clothing/shoes/roguetown/boots
-			armor =	/obj/item/clothing/suit/roguetown/armor/leathervest
+			armor =	/obj/item/clothing/suit/roguetown/armor/leather/vest/v2
 			H.mind.adjust_skillrank(/datum/skill/craft/weaponsmithing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/armorsmithing, 2, TRUE)
 			H.mind.adjust_skillrank(/datum/skill/craft/smelting, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/goblin/chieftain.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/chieftain.dm
@@ -27,7 +27,7 @@
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	belt = /obj/item/storage/belt/rogue/bone/skullbelt
-	armor = /obj/item/clothing/suit/roguetown/armor/bone/chestplate
+	armor = /obj/item/clothing/suit/roguetown/armor/carapace/bone
 	head = /obj/item/clothing/head/roguetown/tribalskull
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	shoes = /obj/item/clothing/shoes/roguetown/boots/bonegreaves

--- a/code/modules/jobs/job_types/roguetown/goblin/tribalguard.dm
+++ b/code/modules/jobs/job_types/roguetown/goblin/tribalguard.dm
@@ -19,7 +19,7 @@
 	head = /obj/item/clothing/head/roguetown/helmet/leather/volfhead
 	shoes = /obj/item/clothing/shoes/roguetown/boots/bonegreaves
 	shirt = /obj/item/clothing/suit/roguetown/shirt/tribalrag
-	armor = /obj/item/clothing/suit/roguetown/armor/bone/chestplate
+	armor = /obj/item/clothing/suit/roguetown/armor/carapace/bone
 	pants = /obj/item/clothing/under/roguetown/loincloth/brown
 	neck = /obj/item/clothing/neck/roguetown/psicross/talisman
 	belt = /obj/item/storage/belt/rogue/bone/skullbelt

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -636,7 +636,7 @@
 
 /datum/crafting_recipe/roguetown/bonearmor
 	name = "bone armor"
-	result = /obj/item/clothing/suit/roguetown/armor/bone/chestplate
+	result = /obj/item/clothing/suit/roguetown/armor/carapace/bone
 	reqs = list(/obj/item/natural/bone = 3,
 				/obj/item/natural/fibers = 1)
 	sellprice = 1

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -609,20 +609,20 @@
 	result = /obj/item/clothing/mask/rogue/skullmask
 	reqs = list(/obj/item/natural/bone = 3,
 				/obj/item/natural/fibers = 1)
-	sellprice = 10
+	sellprice = 8
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/tribalskull
 	name = "wendigo helmet"
 	result = /obj/item/clothing/head/roguetown/tribalskull
 	reqs = list(/obj/item/natural/bone = 3,
 				/obj/item/natural/fibers = 1)
-	sellprice = 10
+	sellprice = 8
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0
+	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/skullcrotch
 	name = "skull belt"
@@ -632,27 +632,27 @@
 	sellprice = 4
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0	
+	craftdiff = 1	
 
 /datum/crafting_recipe/roguetown/bonearmor
 	name = "bone armor"
 	result = /obj/item/clothing/suit/roguetown/armor/carapace/bone
-	reqs = list(/obj/item/natural/bone = 3,
-				/obj/item/natural/fibers = 1)
-	sellprice = 1
+	reqs = list(/obj/item/natural/bone = 6,
+				/obj/item/natural/fibers = 2)
+	sellprice = 16
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0	
+	craftdiff = 2	
 
 /datum/crafting_recipe/roguetown/bonegreaves
 	name = "bone greaves"
 	result = /obj/item/clothing/shoes/roguetown/boots/bonegreaves
 	reqs = list(/obj/item/natural/bone = 2,
 				/obj/item/natural/fibers = 1)
-	sellprice = 1
+	sellprice = 6
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0	
+	craftdiff = 2	
 
 /datum/crafting_recipe/roguetown/antlerhood
 	name = "antlerhood"
@@ -687,10 +687,10 @@
 	result = /obj/item/clothing/neck/roguetown/psicross/skull
 	reqs = list(/obj/item/natural/bone = 1,
 				/obj/item/natural/fibers = 1)
-	sellprice = 1
+	sellprice = 4
 	verbage_simple = "craft"
 	verbage = "crafted"
-	craftdiff = 0		
+	craftdiff = 1		
 
 /datum/crafting_recipe/roguetown/banner
 	name = "battle standard"

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -139,10 +139,10 @@
 	craftdiff = 1	//Slightly harder craft.
 
 /datum/crafting_recipe/roguetown/leather/leathervest
-	name = "leather vest"
-	result = /obj/item/clothing/suit/roguetown/armor/leathervest
+	name = "leather vest (other style)"
+	result = /obj/item/clothing/suit/roguetown/armor/leather/vest/v2
 	reqs = list(/obj/item/natural/hide = 2)
-	sellprice = 26
+	sellprice = 16
 
 /datum/crafting_recipe/roguetown/leather/bikini
 	name = "leather bikini armor"

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -139,7 +139,7 @@
 	craftdiff = 1	//Slightly harder craft.
 
 /datum/crafting_recipe/roguetown/leather/leathervest
-	name = "leather vest (other style)"
+	name = "leather vest"
 	result = /obj/item/clothing/suit/roguetown/armor/leather/vest/v2
 	reqs = list(/obj/item/natural/hide = 2)
 	sellprice = 16

--- a/code/modules/roguetown/roguecrafting/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather.dm
@@ -160,7 +160,7 @@
 
 /datum/crafting_recipe/roguetown/leather/bearfur
 	name = "bear fur"
-	result = /obj/item/clothing/suit/roguetown/armor/hide/bearfur
+	result = /obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur
 	reqs = list(/obj/item/natural/hide = 1,
 				/obj/item/natural/fur = 2)
 	sellprice = 26

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -431,7 +431,7 @@
 
 /datum/crafting_recipe/roguetown/sewing/valorianarmor
 	name = "valorian armor"
-	result = /obj/item/clothing/suit/roguetown/armor/valorianarmor
+	result = /obj/item/clothing/suit/roguetown/armor/gambeson/valorianarmor
 	reqs = list(/obj/item/natural/cloth = 4,
 				/obj/item/natural/fibers = 1)
 	tools = list(/obj/item/needle)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -45,9 +45,10 @@
 	i_type = "Armor"		
 
 /datum/anvil_recipe/armor/shortbrigandine
-	name = "Short Brigandine"
+	name = "Short Brigandine (+1 Cloth)"
 	req_bar = /obj/item/ingot/iron
-	created_item = /obj/item/clothing/suit/roguetown/armor/shortbrigandine
+	additional_items = list(/obj/item/natural/cloth)
+	created_item = /obj/item/clothing/suit/roguetown/armor/plate/half/iron/shortbrigandine
 	craftdiff = 2
 	i_type = "Armor"		
 

--- a/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
+++ b/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
@@ -165,7 +165,7 @@
 		/obj/item/clothing/suit/roguetown/armor/leather/studded/bikini = 45,
 		/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini = 45,
 		/obj/item/clothing/suit/roguetown/armor/leather/vest= 55,
-		/obj/item/clothing/suit/roguetown/armor/hide/bearfur = 30,
+		/obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur = 30,
 		/obj/item/clothing/suit/roguetown/armor/bone/chestplate = 40,
 
 		//helmet

--- a/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
+++ b/modular_hearthstone/code/game/objects/effects/dungeon_chest.dm
@@ -166,7 +166,7 @@
 		/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini = 45,
 		/obj/item/clothing/suit/roguetown/armor/leather/vest= 55,
 		/obj/item/clothing/suit/roguetown/armor/leather/hide/bearfur = 30,
-		/obj/item/clothing/suit/roguetown/armor/bone/chestplate = 40,
+		/obj/item/clothing/suit/roguetown/armor/carapace/bone = 40,
 
 		//helmet
 		/obj/item/clothing/head/roguetown/helmet/kettle = 10,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2d36241e-eb61-459f-b227-7eab6804c9f4)

фиксит наследования добавленной говнокодерами херстоуна брони.
теперь нет брони без статов. разумеется, в пре учитывается присвоение новых путей к атому в крафтах, джоблдаутах, лутбоксах
фиксит только броню, без шлемов, штанов и прочего

долбоёбам которые это добавляли нужно либо глаза раскрыть либо понять принцип наследования