### PR TITLE
electrocution fix (siemens_coefficient in _gloves.dm)

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -3,7 +3,7 @@
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/clothing/gloves.dmi'
-	siemens_coefficient = 0.5
+	siemens_coefficient = 1
 	body_parts_covered = HANDS
 	slot_flags = ITEM_SLOT_GLOVES
 	attack_verb = list("challenged")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cf144e87-b604-448b-bf80-98545ceadfc7)

фиксит родительский объект для абсолютно всех рогуйтаун-перчаток.
до фикса человек, носивший абсолютно любые перчатки, получал на 50% меньше урона от электрических заклинаний мага и книстингеров (даже если напарывался на них ногами, а не бил руками).