### PR TITLE
fix minor spelling mistake in dungeoneer.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/dungeoneer.dm
@@ -46,7 +46,7 @@
 	H.change_stat("strength", 3)
 	H.change_stat("intelligence", -2)
 	H.change_stat("endurance", 2)
-	H.change_stat("constituion", 2)
+	H.change_stat("constitution", 2)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.verbs |= /mob/living/carbon/human/proc/torture_victim
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92d01708-62f0-420a-93f9-70fdf63d8a33)

эта хуйня заставила меня подумать будто бы новая система расовых статов не работает. только после теста понял, что всё ок и копать нужно в другом месте.

кстати, а ведь без консты данжионеру получается играли минимум половину года, если не больше (ошибка была ещё на блекстоуне)